### PR TITLE
Update CommandFramework to the latest snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         </repository>
         <repository>
             <id>bgm</id>
-            <url>https://bgmp.cl/</url>
+            <url>https://maven.bgmp.cl/repo/</url>
         </repository>
         <repository>
             <id>CodeMC</id>
@@ -155,7 +155,7 @@
         <dependency>
             <groupId>com.sk89q</groupId>
             <artifactId>command-framework-bukkit</artifactId>
-            <version>1.9-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>de.tr7zw</groupId>

--- a/src/main/java/fun/lewisdev/deluxehub/DeluxeHub.java
+++ b/src/main/java/fun/lewisdev/deluxehub/DeluxeHub.java
@@ -1,6 +1,10 @@
 package fun.lewisdev.deluxehub;
 
-import com.sk89q.minecraft.util.commands.*;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
+import com.sk89q.minecraft.util.commands.exceptions.CommandPermissionsException;
+import com.sk89q.minecraft.util.commands.exceptions.CommandUsageException;
+import com.sk89q.minecraft.util.commands.exceptions.MissingNestedCommandException;
+import com.sk89q.minecraft.util.commands.exceptions.WrappedCommandException;
 import fun.lewisdev.deluxehub.action.ActionManager;
 import fun.lewisdev.deluxehub.command.CommandManager;
 import fun.lewisdev.deluxehub.config.ConfigManager;
@@ -16,6 +20,7 @@ import fun.lewisdev.deluxehub.utility.TextUtil;
 import fun.lewisdev.deluxehub.utility.UpdateChecker;
 import org.bstats.bukkit.MetricsLite;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.java.JavaPlugin;

--- a/src/main/java/fun/lewisdev/deluxehub/command/CommandManager.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/CommandManager.java
@@ -2,9 +2,9 @@ package fun.lewisdev.deluxehub.command;
 
 import com.sk89q.bukkit.util.BukkitCommandsManager;
 import com.sk89q.bukkit.util.CommandsManagerRegistration;
-import com.sk89q.minecraft.util.commands.CommandException;
 import com.sk89q.minecraft.util.commands.CommandsManager;
-import com.sk89q.minecraft.util.commands.SimpleInjector;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
+import com.sk89q.minecraft.util.commands.injection.SimpleInjector;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.command.commands.*;
 import fun.lewisdev.deluxehub.command.commands.gamemode.*;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/ClearchatCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/ClearchatCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
-import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.annotations.Command;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/DeluxeHubCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/DeluxeHubCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
-import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.annotations.Command;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.command.CommandManager;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/FlyCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/FlyCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
-import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.annotations.Command;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/LobbyCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/LobbyCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
-import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.annotations.Command;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.module.ModuleType;
 import fun.lewisdev.deluxehub.module.modules.world.LobbySpawn;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/LockchatCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/LockchatCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
-import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.annotations.Command;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/SetLobbyCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/SetLobbyCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
-import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.annotations.Command;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/VanishCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/VanishCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
-import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.annotations.Command;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/AdventureCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/AdventureCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands.gamemode;
 
-import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
-import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.annotations.Command;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/CreativeCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/CreativeCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands.gamemode;
 
-import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
-import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.annotations.Command;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/GamemodeCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/GamemodeCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands.gamemode;
 
-import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
-import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.annotations.Command;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/SpectatorCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/SpectatorCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands.gamemode;
 
-import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
-import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.annotations.Command;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/SurvivalCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/SurvivalCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands.gamemode;
 
-import com.sk89q.minecraft.util.commands.Command;
 import com.sk89q.minecraft.util.commands.CommandContext;
-import com.sk89q.minecraft.util.commands.CommandException;
+import com.sk89q.minecraft.util.commands.annotations.Command;
+import com.sk89q.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHub;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;


### PR DESCRIPTION
Hey Lewiz!

I've started to maintain the CommandFramework project in a better manner since a few days now, and I remembered your plugin was making use of it! This commit updates the framework to its latest version and re-directs to my new maven repository.

As for my project, I decided to take down the old repository I had on my github, to re-upload it with the full commit history from where I had taken it from, to properly credit all past contributors. Therefore though, I had to manually re-add the little pull request you had made for command aliases, so it is there! it's just that I couldn't really get your commits to show up in the history for obvious reasons. Your star was also removed :(.

Anyhow, I may contribute to improving the way you have set up the commands, as I see a lot of boilerplate the framework gets around swiftly through some extra annotations.

Thanks for the support!