### PR TITLE
Update Launchpad.java

### DIFF
--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/world/Launchpad.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/world/Launchpad.java
@@ -36,8 +36,6 @@ public class Launchpad extends Module {
         topBlock = XMaterial.matchXMaterial(config.getString("launchpad.top_block")).get().parseMaterial();
         bottomBlock = XMaterial.matchXMaterial(config.getString("launchpad.bottom_block")).get().parseMaterial();
 
-        if (launch > 4.0) launch = 4.0;
-        if (launchY > 4.0) launchY = 4.0;
     }
 
     @Override


### PR DESCRIPTION
The limitation of these values make larger hubs have issues with the launch pads. For example, a larger hub may not be able to launch their players close to a portal rendering the launch pads useless.