### PR TITLE
Implement improved "jump charge" style double jump.

### DIFF
--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/player/DoubleJump.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/player/DoubleJump.java
@@ -8,17 +8,20 @@ import fun.lewisdev.deluxehub.cooldown.CooldownType;
 import fun.lewisdev.deluxehub.module.Module;
 import fun.lewisdev.deluxehub.module.ModuleType;
 import org.bukkit.GameMode;
-import org.bukkit.Material;
+import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerToggleFlightEvent;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class DoubleJump extends Module {
@@ -27,6 +30,8 @@ public class DoubleJump extends Module {
     private double launch;
     private double launchY;
     private List<String> actions;
+
+    private final Map<UUID, Boolean> canJump = new HashMap<>();
 
     public DoubleJump(DeluxeHubPlugin plugin) {
         super(plugin, ModuleType.DOUBLE_JUMP);
@@ -50,7 +55,6 @@ public class DoubleJump extends Module {
 
     @EventHandler
     public void onPlayerToggleFlight(PlayerToggleFlightEvent event) {
-
         Player player = event.getPlayer();
 
         // Perform checks
@@ -58,24 +62,46 @@ public class DoubleJump extends Module {
         else if (inDisabledWorld(player.getLocation())) return;
         else if (player.getGameMode() == GameMode.CREATIVE || player.getGameMode() == GameMode.SPECTATOR) return;
         else if (!event.isFlying()) return;
-        else if (player.getWorld().getBlockAt(player.getLocation().subtract(0, 2, 0)).getType() == Material.AIR) {
-            event.setCancelled(true);
-            return;
-        }
 
-        // All pre-checks passed, now handle double jump
-        event.setCancelled(true);
-
-        // Check for cooldown
         UUID uuid = player.getUniqueId();
-        if (!tryCooldown(uuid, CooldownType.DOUBLE_JUMP, cooldownDelay)) {
-            Messages.DOUBLE_JUMP_COOLDOWN.send(player, "%time%", getCooldown(uuid, CooldownType.DOUBLE_JUMP));
+
+        // Check if the player has a "jump charge"
+        if (canJump.containsKey(uuid) && canJump.get(uuid)) {
+            // Check for cooldown
+            if (!tryCooldown(uuid, CooldownType.DOUBLE_JUMP, cooldownDelay)) {
+                Messages.DOUBLE_JUMP_COOLDOWN.send(player, "%time%", getCooldown(uuid, CooldownType.DOUBLE_JUMP));
+                event.setCancelled(true);
+                return;
+            }
+
+            // Execute double jump
+            player.setVelocity(player.getLocation().getDirection().multiply(launch).setY(launchY));
+            executeActions(player, actions);
+
+            //Set the players "jump charge" to false
+            canJump.remove(uuid);
+            canJump.put(uuid, false);
+        }
+        event.setCancelled(true);
+    }
+
+    @EventHandler
+    public void onPlayerMove(PlayerMoveEvent event) {
+        // Only check if the player is on the ground if they have moved to a new block for performance, this is the same thing WorldGuard does.
+        Location from = event.getFrom();
+        Location to = event.getTo();
+
+        if (to != null && from.getBlockX() == to.getBlockX() && from.getBlockY() == to.getBlockY() && from.getBlockZ() == to.getBlockZ()) {
             return;
         }
 
-        // Execute double jump
-        player.setVelocity(player.getLocation().getDirection().multiply(launch).setY(launchY));
-        executeActions(player, actions);
+        // Set the players "jump charge" to true if they are on solid ground.
+        Player player = event.getPlayer();
+        UUID uuid = player.getUniqueId();
+        if (player.getWorld().getBlockAt(player.getLocation().subtract(0, 1, 0)).getBlockData().getMaterial().isSolid() && canJump.containsKey(uuid) && !canJump.get(uuid)) {
+            canJump.remove(uuid);
+            canJump.put(uuid, true);
+        }
     }
 
     @EventHandler
@@ -83,13 +109,16 @@ public class DoubleJump extends Module {
         Player player = event.getPlayer();
         if (player.getGameMode() != GameMode.CREATIVE && player.getGameMode() != GameMode.SPECTATOR && !inDisabledWorld(player.getLocation())) {
             player.getPlayer().setAllowFlight(true);
+            if (!canJump.containsKey(player.getUniqueId())) canJump.put(player.getUniqueId(), true);
         }
     }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        if (player.getGameMode() != GameMode.CREATIVE && player.getGameMode() != GameMode.SPECTATOR)
+        if (player.getGameMode() != GameMode.CREATIVE && player.getGameMode() != GameMode.SPECTATOR) {
             player.getPlayer().setAllowFlight(true);
+            if (!canJump.containsKey(player.getUniqueId())) canJump.put(player.getUniqueId(), true);
+        }
     }
 }


### PR DESCRIPTION
This replaces the check for a block beneath you within Double Jump with a "jump charge". This results in a much more intuitive double jump where the player can jump once any time after leaving the ground and cannot jump again until after touching the ground again.

Whenever the player touches the ground, they gain a "jump charge". If they double jump, they lose this "jump charge" and must land on the ground again to double jump again.