### PR TITLE
Add Restricted Parameter to Bungee Action

### DIFF
--- a/src/main/java/fun/lewisdev/deluxehub/action/actions/BungeeAction.java
+++ b/src/main/java/fun/lewisdev/deluxehub/action/actions/BungeeAction.java
@@ -19,7 +19,7 @@ public class BungeeAction implements Action {
         if(data.contains(";")) {
             String[] params = data.split(";", 2);
             data = params[0];
-            if(params[1].toUpperCase().equals("RESTRICTED")) {
+            if(params[1].strip().toUpperCase().equals("RESTRICTED")) {
                 if(!player.hasPermission("bungeecord.server."+data)) {
                     player.sendMessage(TextUtil.color("&cYou don't have permission to access "+data));
                     return;

--- a/src/main/java/fun/lewisdev/deluxehub/action/actions/BungeeAction.java
+++ b/src/main/java/fun/lewisdev/deluxehub/action/actions/BungeeAction.java
@@ -5,6 +5,7 @@ import com.google.common.io.ByteStreams;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.action.Action;
 import org.bukkit.entity.Player;
+import fun.lewisdev.deluxehub.utility.TextUtil;
 
 public class BungeeAction implements Action {
 
@@ -15,6 +16,16 @@ public class BungeeAction implements Action {
 
     @Override
     public void execute(DeluxeHubPlugin plugin, Player player, String data) {
+        if(data.contains(";")) {
+            String[] params = data.split(";", 2);
+            data = params[0];
+            if(params[1].toUpperCase().equals("RESTRICTED")) {
+                if(!player.hasPermission("bungeecord.server."+data)) {
+                    player.sendMessage(TextUtil.color("&cYou don't have permission to access "+data));
+                    return;
+                }
+            }
+        }
         ByteArrayDataOutput out = ByteStreams.newDataOutput();
         out.writeUTF("ConnectOther");
         out.writeUTF(player.getName());


### PR DESCRIPTION
Simple patch adding a restricted parameter to the [BUNGEE] action.

`[BUNGEE] servername` sends the player to the specified bungee server as normal.

`[BUNGEE] servername;RESTRICTED` checks that the player has a `bungeecord.server.servername` permission before sending.

If the player does not have the relevant permission an error is sent: "You do not have permission to access servername".