### PR TITLE
Added 1.20+ Support and Teleport Bow Item

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -51,7 +51,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>org.bstats:bstats-bukkit-lite</include>
-                                    <include>com.github.BGMP.CommandFramework:command-framework-bukkit</include>
+                                    <include>cl.bgm:command-framework-bukkit</include>
                                     <include>javax.inject:javax.inject</include>
                                     <include>de.tr7zw:item-nbt-api</include>
                                 </includes>
@@ -109,6 +109,10 @@
             <id>mojang</id>
             <url>https://libraries.minecraft.net/</url>
         </repository>
+        <repository>
+            <id>bgm</id>
+            <url>https://maven.bgm.cl/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -119,16 +123,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.md-5</groupId>
-            <artifactId>bungeecord-chat</artifactId>
-            <version>1.16-R0.1</version>
+            <groupId>com.mojang</groupId>
+            <artifactId>authlib</artifactId>
+            <version>3.11.50</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.mojang</groupId>
-            <artifactId>authlib</artifactId>
-            <version>1.5.21</version>
-            <scope>provided</scope>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>24.0.0</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
@@ -153,20 +157,22 @@
             <version>1.2</version>
         </dependency>
         <dependency>
-            <groupId>com.github.BGMP.CommandFramework</groupId>
+            <groupId>cl.bgm</groupId>
             <artifactId>command-framework-bukkit</artifactId>
-            <version>master</version>
+            <version>1.0.3-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
             <version>2.11.3</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.github.shynixn.headdatabase</groupId>
             <artifactId>hdb-api</artifactId>
             <version>1.0</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fun.lewisdev</groupId>
     <artifactId>DeluxeHub</artifactId>
-    <version>3.5.3</version>
+    <version>3.5.4</version>
     <packaging>jar</packaging>
 
     <name>DeluxeHub</name>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.10.0-SNAPSHOT</version>
+            <version>2.11.3</version>
         </dependency>
         <dependency>
             <groupId>com.github.shynixn.headdatabase</groupId>

--- a/src/main/java/fun/lewisdev/deluxehub/DeluxeHubPlugin.java
+++ b/src/main/java/fun/lewisdev/deluxehub/DeluxeHubPlugin.java
@@ -1,10 +1,6 @@
 package fun.lewisdev.deluxehub;
 
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandPermissionsException;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandUsageException;
-import cl.bgmp.minecraft.util.commands.exceptions.MissingNestedCommandException;
-import cl.bgmp.minecraft.util.commands.exceptions.WrappedCommandException;
+import cl.bgm.minecraft.util.commands.exceptions.*;
 import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
 import fun.lewisdev.deluxehub.action.ActionManager;
 import fun.lewisdev.deluxehub.command.CommandManager;
@@ -17,7 +13,6 @@ import fun.lewisdev.deluxehub.inventory.InventoryManager;
 import fun.lewisdev.deluxehub.module.ModuleManager;
 import fun.lewisdev.deluxehub.module.ModuleType;
 import fun.lewisdev.deluxehub.module.modules.hologram.HologramManager;
-import fun.lewisdev.deluxehub.utility.TextUtil;
 import fun.lewisdev.deluxehub.utility.UpdateChecker;
 import org.bstats.bukkit.MetricsLite;
 import org.bukkit.Bukkit;

--- a/src/main/java/fun/lewisdev/deluxehub/command/CommandManager.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/CommandManager.java
@@ -1,10 +1,10 @@
 package fun.lewisdev.deluxehub.command;
 
-import cl.bgmp.bukkit.util.BukkitCommandsManager;
-import cl.bgmp.bukkit.util.CommandsManagerRegistration;
-import cl.bgmp.minecraft.util.commands.CommandsManager;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
-import cl.bgmp.minecraft.util.commands.injection.SimpleInjector;
+import cl.bgm.bukkit.util.BukkitCommandsManager;
+import cl.bgm.bukkit.util.CommandsManagerRegistration;
+import cl.bgm.minecraft.util.commands.CommandsManager;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.injection.SimpleInjector;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.command.commands.*;
 import fun.lewisdev.deluxehub.command.commands.gamemode.*;
@@ -12,7 +12,8 @@ import fun.lewisdev.deluxehub.config.ConfigType;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class CommandManager {
 

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/ClearchatCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/ClearchatCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import cl.bgmp.minecraft.util.commands.CommandContext;
-import cl.bgmp.minecraft.util.commands.annotations.Command;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.CommandContext;
+import cl.bgm.minecraft.util.commands.annotations.Command;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/DeluxeHubCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/DeluxeHubCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import cl.bgmp.minecraft.util.commands.CommandContext;
-import cl.bgmp.minecraft.util.commands.annotations.Command;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.CommandContext;
+import cl.bgm.minecraft.util.commands.annotations.Command;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.command.CommandManager;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/FlyCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/FlyCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import cl.bgmp.minecraft.util.commands.CommandContext;
-import cl.bgmp.minecraft.util.commands.annotations.Command;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.CommandContext;
+import cl.bgm.minecraft.util.commands.annotations.Command;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/LobbyCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/LobbyCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import cl.bgmp.minecraft.util.commands.CommandContext;
-import cl.bgmp.minecraft.util.commands.annotations.Command;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.CommandContext;
+import cl.bgm.minecraft.util.commands.annotations.Command;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.module.ModuleType;
 import fun.lewisdev.deluxehub.module.modules.world.LobbySpawn;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/LockchatCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/LockchatCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import cl.bgmp.minecraft.util.commands.CommandContext;
-import cl.bgmp.minecraft.util.commands.annotations.Command;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.CommandContext;
+import cl.bgm.minecraft.util.commands.annotations.Command;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/SetLobbyCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/SetLobbyCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import cl.bgmp.minecraft.util.commands.CommandContext;
-import cl.bgmp.minecraft.util.commands.annotations.Command;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.CommandContext;
+import cl.bgm.minecraft.util.commands.annotations.Command;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/VanishCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/VanishCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands;
 
-import cl.bgmp.minecraft.util.commands.CommandContext;
-import cl.bgmp.minecraft.util.commands.annotations.Command;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.CommandContext;
+import cl.bgm.minecraft.util.commands.annotations.Command;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/AdventureCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/AdventureCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands.gamemode;
 
-import cl.bgmp.minecraft.util.commands.CommandContext;
-import cl.bgmp.minecraft.util.commands.annotations.Command;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.CommandContext;
+import cl.bgm.minecraft.util.commands.annotations.Command;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/CreativeCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/CreativeCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands.gamemode;
 
-import cl.bgmp.minecraft.util.commands.CommandContext;
-import cl.bgmp.minecraft.util.commands.annotations.Command;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.CommandContext;
+import cl.bgm.minecraft.util.commands.annotations.Command;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/GamemodeCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/GamemodeCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands.gamemode;
 
-import cl.bgmp.minecraft.util.commands.CommandContext;
-import cl.bgmp.minecraft.util.commands.annotations.Command;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.CommandContext;
+import cl.bgm.minecraft.util.commands.annotations.Command;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/SpectatorCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/SpectatorCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands.gamemode;
 
-import cl.bgmp.minecraft.util.commands.CommandContext;
-import cl.bgmp.minecraft.util.commands.annotations.Command;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.CommandContext;
+import cl.bgm.minecraft.util.commands.annotations.Command;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/SurvivalCommand.java
+++ b/src/main/java/fun/lewisdev/deluxehub/command/commands/gamemode/SurvivalCommand.java
@@ -1,8 +1,8 @@
 package fun.lewisdev.deluxehub.command.commands.gamemode;
 
-import cl.bgmp.minecraft.util.commands.CommandContext;
-import cl.bgmp.minecraft.util.commands.annotations.Command;
-import cl.bgmp.minecraft.util.commands.exceptions.CommandException;
+import cl.bgm.minecraft.util.commands.CommandContext;
+import cl.bgm.minecraft.util.commands.annotations.Command;
+import cl.bgm.minecraft.util.commands.exceptions.CommandException;
 import fun.lewisdev.deluxehub.DeluxeHubPlugin;
 import fun.lewisdev.deluxehub.Permissions;
 import fun.lewisdev.deluxehub.config.Messages;

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/HotbarManager.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/HotbarManager.java
@@ -6,6 +6,7 @@ import fun.lewisdev.deluxehub.module.Module;
 import fun.lewisdev.deluxehub.module.ModuleType;
 import fun.lewisdev.deluxehub.module.modules.hotbar.items.CustomItem;
 import fun.lewisdev.deluxehub.module.modules.hotbar.items.PlayerHider;
+import fun.lewisdev.deluxehub.module.modules.hotbar.items.TeleportBow;
 import fun.lewisdev.deluxehub.utility.ItemStackBuilder;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -28,7 +29,6 @@ public class HotbarManager extends Module {
         FileConfiguration config = getConfig(ConfigType.SETTINGS);
 
         if (config.getBoolean("custom_join_items.enabled")) {
-
             for (String entry : config.getConfigurationSection("custom_join_items.items").getKeys(false)) {
                 ItemStack item = ItemStackBuilder.getItemStack(config.getConfigurationSection("custom_join_items.items." + entry)).build();
                 CustomItem customItem = new CustomItem(this, item, config.getInt("custom_join_items.items." + entry + ".slot"), entry);
@@ -51,6 +51,19 @@ public class HotbarManager extends Module {
             playerHider.setAllowMovement(config.getBoolean("player_hider.disable_inventory_movement"));
 
             registerHotbarItem(playerHider);
+        }
+
+        if (config.getBoolean("teleport_bow.enabled")) {
+            ItemStack item = ItemStackBuilder.getItemStack(config.getConfigurationSection("teleport_bow.item")).build();
+
+            // Add arrow infinity enchantment
+            item.addUnsafeEnchantment(org.bukkit.enchantments.Enchantment.ARROW_INFINITE, 1);
+
+            TeleportBow teleportBow = new TeleportBow(this, item, config.getInt("teleport_bow.slot"), "TELEPORT_BOW");
+
+            teleportBow.setAllowMovement(config.getBoolean("teleport_bow.disable_inventory_movement"));
+
+            registerHotbarItem(teleportBow);
         }
 
         giveItems();

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/items/TeleportBow.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/items/TeleportBow.java
@@ -108,8 +108,6 @@ public class TeleportBow extends HotbarItem {
             return;
         }
 
-        System.out.println("Projectile hit");
-
         if (!entity.hasMetadata("teleportEntity")) {
             return;
         }

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/items/TeleportBow.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/hotbar/items/TeleportBow.java
@@ -1,0 +1,145 @@
+package fun.lewisdev.deluxehub.module.modules.hotbar.items;
+
+import de.tr7zw.changeme.nbtapi.NBTItem;
+import fun.lewisdev.deluxehub.config.ConfigType;
+import fun.lewisdev.deluxehub.module.modules.hotbar.HotbarItem;
+import fun.lewisdev.deluxehub.module.modules.hotbar.HotbarManager;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.event.player.PlayerItemDamageEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.projectiles.ProjectileSource;
+
+public class TeleportBow extends HotbarItem {
+
+    private final int cooldown;
+    private final int arrowSlot;
+
+    public TeleportBow(HotbarManager hotbarManager, ItemStack item, int slot, String key) {
+        super(hotbarManager, item, slot, key);
+
+        FileConfiguration config = getHotbarManager().getConfig(ConfigType.SETTINGS);
+
+        this.cooldown = config.getInt("teleport_bow.cooldown", 3);
+        this.arrowSlot = config.getInt("teleport_bow.arrow_slot", 9);
+    }
+
+    @Override
+    protected void onInteract(Player player) {
+        // DO NOTHING
+    }
+
+    @Override
+    public void giveItem(Player player) {
+        super.giveItem(player);
+
+        // Ensure the player has permission to use this item
+        if (getPermission() != null && !player.hasPermission(getPermission())) {
+            return;
+        }
+
+        ItemStack arrow = new ItemStack(org.bukkit.Material.ARROW);
+
+        // Give the player arrows
+        player.getInventory().setItem(arrowSlot, arrow);
+    }
+
+    @EventHandler
+    public void onEntityLaunch(ProjectileLaunchEvent event) {
+        Projectile entity = event.getEntity();
+        if (getHotbarManager().inDisabledWorld(entity.getWorld())) {
+            return;
+        }
+
+        if (!(entity.getShooter() instanceof Player) || !(entity instanceof Arrow)) {
+            return;
+        }
+
+        Player player = (Player) entity.getShooter();
+        PlayerInventory inventory = player.getInventory();
+        ItemStack itemInMainHand = inventory.getItemInMainHand();
+        String hotbarItem = new NBTItem(itemInMainHand).getString("hotbarItem");
+        if (hotbarItem == null || !hotbarItem.equals(getKey())) {
+            return;
+        }
+
+        // Apply cooldown
+        player.setCooldown(itemInMainHand.getType(), cooldown * 20);
+        // Add entity metadata to be used in ProjectileHitEvent
+        entity.setMetadata("teleportEntity", new FixedMetadataValue(getPlugin(), player.getUniqueId()));
+    }
+
+    @EventHandler
+    public void onPlayerDamageItem(PlayerItemDamageEvent event) {
+        Player player = event.getPlayer();
+        // Ensure the player has permission to use this item
+        if (getPermission() != null && !player.hasPermission(getPermission())) {
+            return;
+        }
+
+        ItemStack item = event.getItem();
+        String hotbarItem = new NBTItem(item).getString("hotbarItem");
+        if (hotbarItem == null || !hotbarItem.equals(getKey())) {
+            return;
+        }
+
+        // Cancel the event, since the player is not supposed to take damage
+        event.setCancelled(true);
+    }
+
+    @EventHandler
+    public void onProjectileHit(ProjectileHitEvent event) {
+        Projectile entity = event.getEntity();
+        if (getHotbarManager().inDisabledWorld(entity.getWorld())) {
+            return;
+        }
+
+        if (!(entity instanceof Arrow)) {
+            return;
+        }
+
+        System.out.println("Projectile hit");
+
+        if (!entity.hasMetadata("teleportEntity")) {
+            return;
+        }
+
+        ProjectileSource shooter = entity.getShooter();
+        if (!(shooter instanceof Player)) {
+            return;
+        }
+
+        BlockFace hitBlockFace = event.getHitBlockFace();
+        Block block = event.getHitBlock();
+        // Ensure the arrow hit a block
+        if (hitBlockFace == null || block == null) {
+            return;
+        }
+
+        // Get the Location of the block using hitBlockFace & block
+        Location directionLocation = block.getLocation().add(hitBlockFace.getDirection());
+        Location location = directionLocation.add(0.5, hitBlockFace.getModY() * 1.5, 0.5);
+
+        Player player = (Player) shooter;
+
+        // Teleport the player
+        player.teleport(location);
+
+        // Spawn particles
+        player.getWorld().spawnParticle(org.bukkit.Particle.PORTAL, directionLocation, 100);
+
+        // Remove the arrow
+        entity.remove();
+    }
+
+}

--- a/src/main/java/fun/lewisdev/deluxehub/utility/TextUtil.java
+++ b/src/main/java/fun/lewisdev/deluxehub/utility/TextUtil.java
@@ -1,12 +1,9 @@
 package fun.lewisdev.deluxehub.utility;
 
 import fun.lewisdev.deluxehub.utility.color.IridiumColorAPI;
-import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Color;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class TextUtil {
 

--- a/src/main/java/fun/lewisdev/deluxehub/utility/reflection/ReflectionUtils.java
+++ b/src/main/java/fun/lewisdev/deluxehub/utility/reflection/ReflectionUtils.java
@@ -23,9 +23,9 @@ package fun.lewisdev.deluxehub.utility.reflection;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -105,18 +105,18 @@ public class ReflectionUtils {
         GET_HANDLE = getHandle;
     }
 
-    private ReflectionUtils() {}
+    private ReflectionUtils() {
+    }
 
     /**
      * Get a NMS (net.minecraft.server) class.
      *
      * @param name the name of the class.
-     *
      * @return the NMS class or null if not found.
      * @since 1.0.0
      */
-    @Nullable
-    public static Class<?> getNMSClass(@Nonnull String name) {
+    @NotNull
+    public static Class<?> getNMSClass(@NotNull String name) {
         try {
             return Class.forName(NMS + name);
         } catch (ClassNotFoundException ex) {
@@ -131,13 +131,12 @@ public class ReflectionUtils {
      *
      * @param player  the player to send the packet to.
      * @param packets the packets to send.
-     *
      * @return the async thread handling the packet.
      * @see #sendPacketSync(Player, Object...)
      * @since 1.0.0
      */
-    @Nonnull
-    public static CompletableFuture<Void> sendPacket(@Nonnull Player player, @Nonnull Object... packets) {
+    @NotNull
+    public static CompletableFuture<Void> sendPacket(@NotNull Player player, @NotNull Object... packets) {
         return CompletableFuture.runAsync(() -> sendPacketSync(player, packets))
                 .exceptionally(ex -> {
                     ex.printStackTrace();
@@ -150,11 +149,10 @@ public class ReflectionUtils {
      *
      * @param player  the player to send the packet to.
      * @param packets the packets to send.
-     *
      * @see #sendPacket(Player, Object...)
      * @since 2.0.0
      */
-    public static void sendPacketSync(@Nonnull Player player, @Nonnull Object... packets) {
+    public static void sendPacketSync(@NotNull Player player, @NotNull Object... packets) {
         try {
             Object handle = GET_HANDLE.invoke(player);
             Object connection = PLAYER_CONNECTION.invoke(handle);
@@ -169,7 +167,7 @@ public class ReflectionUtils {
     }
 
     @Nullable
-    public static Object getHandle(@Nonnull Player player) {
+    public static Object getHandle(@NotNull Player player) {
         Objects.requireNonNull(player, "Cannot get handle of null player");
         try {
             return GET_HANDLE.invoke(player);
@@ -180,7 +178,7 @@ public class ReflectionUtils {
     }
 
     @Nullable
-    public static Object getConnection(@Nonnull Player player) {
+    public static Object getConnection(@NotNull Player player) {
         Objects.requireNonNull(player, "Cannot get connection of null player");
         try {
             Object handle = GET_HANDLE.invoke(player);
@@ -195,12 +193,11 @@ public class ReflectionUtils {
      * Get a CraftBukkit (org.bukkit.craftbukkit) class.
      *
      * @param name the name of the class to load.
-     *
      * @return the CraftBukkit class or null if not found.
      * @since 1.0.0
      */
     @Nullable
-    public static Class<?> getCraftClass(@Nonnull String name) {
+    public static Class<?> getCraftClass(@NotNull String name) {
         try {
             return Class.forName(CRAFTBUKKIT + name);
         } catch (ClassNotFoundException ex) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -382,3 +382,28 @@ player_hider:
     display_name: '&dPlayers &8&l> &cHidden &7(Right-Click)'
     lore:
       - '&7Click to show all players!'
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+# | TELEPORT BOW                             |
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+teleport_bow:
+  # Should the teleport bow feature be enabled?
+  enabled: true
+  # Slot the item should be given to?
+  slot: 0
+  # Slot the arrow should be given to?
+  arrow_slot: 1
+  # Should we prevent them from moving/dropping the item?
+  disable_inventory_movement: true
+  # Cooldown in seconds
+  # Set to 0 to disable
+  cooldown: 3
+  # The Teleport Bow item
+  item:
+    material: BOW
+    amount: 1
+    display_name: "&dTeleport Bow"
+    lore:
+      - "&7Right-click to teleport to where the arrow lands!"
+    item_flags:
+      - HIDE_ENCHANTS

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: ${project.name}
-author: ItsLewizzz
+authors: [ ItsLewizzz, VertCode ]
 version: ${project.version}
 description: ${project.description}
 website: ${project.url}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,12 +1,12 @@
 name: ${project.name}
-authors: [ ItsLewizzz, VertCode ]
+authors: [ ItsLewizzz ]
 version: ${project.version}
 description: ${project.description}
 website: ${project.url}
 api-version: 1.13
 main: fun.lewisdev.deluxehub.DeluxeHubPlugin
-loadbefore: [Essentials]
-softdepend: [PlaceholderAPI, HeadDatabase, Multiverse-Core]
+loadbefore: [ Essentials ]
+softdepend: [ PlaceholderAPI, HeadDatabase, Multiverse-Core ]
 permissions:
   deluxehub.*:
     description: Gives access to all DeluxeHub permissions


### PR DESCRIPTION
Added 1.20+ Support
Added Teleport Bow item 
Updated Dependencies

**Reasoning for Teleport Bow:**
The Teleport Bow functionality has become increasingly popular in lobbies, with many servers utilizing custom or external plugins for the teleport bow. By adding the Teleport Bow directly into DeluxeHub, we provide server owners and players with a convenient all-in-one solution.