### PR TITLE
A new chat formatting module 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fun.lewisdev</groupId>
     <artifactId>DeluxeHub</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
     <packaging>jar</packaging>
 
     <name>DeluxeHub</name>

--- a/src/main/java/fun/lewisdev/deluxehub/Permissions.java
+++ b/src/main/java/fun/lewisdev/deluxehub/Permissions.java
@@ -23,7 +23,6 @@ public enum Permissions {
     BLOCKED_COMMANDS_BYPASS("bypass.commands"),
     LOCK_CHAT_BYPASS("bypass.lockchat"),
     GROUP_CHAT("chat.group"),
-
     COLOR_CHAT("chat.color"),
     ANTI_WDL_BYPASS("bypass.antiwdl"),
     DOUBLE_JUMP_BYPASS("bypass.doublejump"),

--- a/src/main/java/fun/lewisdev/deluxehub/Permissions.java
+++ b/src/main/java/fun/lewisdev/deluxehub/Permissions.java
@@ -22,6 +22,9 @@ public enum Permissions {
     ANTI_SWEAR_BYPASS("bypass.antiswear"),
     BLOCKED_COMMANDS_BYPASS("bypass.commands"),
     LOCK_CHAT_BYPASS("bypass.lockchat"),
+    GROUP_CHAT("chat.group"),
+
+    COLOR_CHAT("chat.color"),
     ANTI_WDL_BYPASS("bypass.antiwdl"),
     DOUBLE_JUMP_BYPASS("bypass.doublejump"),
 

--- a/src/main/java/fun/lewisdev/deluxehub/module/ModuleManager.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/ModuleManager.java
@@ -50,6 +50,7 @@ public class ModuleManager {
         registerModule(new Launchpad(plugin), "launchpad.enabled");
         registerModule(new ScoreboardManager(plugin), "scoreboard.enabled");
         registerModule(new TablistManager(plugin), "tablist.enabled");
+        registerModule(new ChatFormat(plugin), "chat_format.enabled");
         registerModule(new AutoBroadcast(plugin), "announcements.enabled");
         registerModule(new AntiSwear(plugin), "anti_swear.enabled");
         registerModule(new ChatCommandBlock(plugin), "command_block.enabled");

--- a/src/main/java/fun/lewisdev/deluxehub/module/ModuleType.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/ModuleType.java
@@ -4,6 +4,7 @@ public enum ModuleType {
 
     ANTI_WDL,
     CHAT_LOCK,
+    CHAT_FORMAT,
     CUSTOM_COMMANDS,
     DOUBLE_JUMP,
     LAUNCHPAD,

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/chat/ChatFormat.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/chat/ChatFormat.java
@@ -1,0 +1,89 @@
+package fun.lewisdev.deluxehub.module.modules.chat;
+
+import fun.lewisdev.deluxehub.DeluxeHubPlugin;
+import fun.lewisdev.deluxehub.Permissions;
+import fun.lewisdev.deluxehub.config.ConfigType;
+import fun.lewisdev.deluxehub.module.Module;
+import fun.lewisdev.deluxehub.module.ModuleType;
+import fun.lewisdev.deluxehub.utility.PlaceholderUtil;
+import fun.lewisdev.deluxehub.utility.TextUtil;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ChatFormat extends Module {
+
+    private DeluxeHubPlugin plugin;
+    private List<String> groups;
+
+    public ChatFormat(DeluxeHubPlugin plugin) {
+        super(plugin, ModuleType.CHAT_FORMAT);
+
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void onEnable() {
+        groups = new ArrayList<>();
+        loadGroups();
+    }
+
+    @Override
+    public void onDisable() {
+
+        groups.clear();
+        loadGroups();
+
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerChat(AsyncPlayerChatEvent event){
+        String message = event.getMessage();
+        Player player = event.getPlayer();
+
+        String format = getPlayerFormat(player);
+
+        if(format != null){
+            format = PlaceholderUtil.setPlaceholders(format, player);
+            format = TextUtil.color(format);
+
+            if(player.hasPermission(Permissions.COLOR_CHAT.getPermission()))
+                message = TextUtil.color(message);
+
+            event.setFormat(format.replace("%message%", message));
+            return;
+        }
+
+        plugin.getLogger().severe("============= DELUXEHUB CHAT FORMAT =============");
+        plugin.getLogger().severe("Can't find the default chat formatting!");
+        plugin.getLogger().severe("Create it in the configuration file");
+        plugin.getLogger().severe("============= DELUXEHUB CHAT FORMAT =============");
+
+    }
+
+    private String getPlayerGroup(Player player){
+        for (String group : groups){
+            if(player.hasPermission(Permissions.GROUP_CHAT.getPermission() + "." + group)){
+                return group;
+            }
+        }
+        return "default";
+    }
+
+    private String getPlayerFormat(Player player){
+        return getConfig(ConfigType.SETTINGS).getString("chat_format.group_formats." + getPlayerGroup(player));
+    }
+
+    private void loadGroups(){
+        ConfigurationSection section = getConfig(ConfigType.SETTINGS).getConfigurationSection("chat_format.group_formats");
+        groups.addAll(section.getKeys(false));
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -207,6 +207,12 @@ double_jump:
 # | CHAT MANAGEMENT                          |
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 
+chat_format:
+  enabled: true
+
+  group_formats:
+    default: "&f%player% &7» &f%message%"
+
 command_block:
   # Should the command blocker feature be enabled?
   enabled: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -208,9 +208,16 @@ double_jump:
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 
 chat_format:
+  # Should the chat formatting feature be enabled?
   enabled: true
 
+  # Format is assigned relative to the assigned permissions from the highest priority
+  # Therefore, the lowest rank should always be at the bottom and the highest at the top
+  # Adding formatting: deluxehub.chat.group.<group>
+  # If you want a player to be able to use coloring in chat add permission: deluxehub.chat.color
   group_formats:
+    admin: "&eADMIN &f%player% &7» &f%message%"
+    # Default formatting, DO NOT REMOVE THIS
     default: "&f%player% &7» &f%message%"
 
 command_block:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -17,6 +17,7 @@ permissions:
       deluxehub.item.*: true
       deluxehub.player.*: true
       deluxehub.block.*: true
+      deluxehub.chat.color: true
   deluxehub.command.*:
     description: Gives access to all command permissions
     children:


### PR DESCRIPTION
I thought a cool addition to the plugin would be to add chat formatting. This would allow additional users of this plugin to ogle an additional plugin for this formatting :D

In the future, an extension to LuckPermsAPI or Vault could be added.

I have added the ability to write messages by formatting using deluxehub.chat.color permissions, and to format the chat by group, which can be set in your own custom way. When assigning such a group for a player, use deluxehub.chat.group.<group> permissions.