### PR TITLE
Dynamic worlds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fun.lewisdev</groupId>
     <artifactId>DeluxeHub</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
     <packaging>jar</packaging>
 
     <name>DeluxeHub</name>
@@ -17,8 +17,11 @@
         <developer>
             <name>ItsLewizzz</name>
             <url>https://lewisdev.fun</url>
+			<!-- I dont know about your policy to add contributors to this section -->
         </developer>
     </developers>
+	
+	
 
     <properties>
         <java.version>1.8</java.version>

--- a/src/main/java/fun/lewisdev/deluxehub/DeluxeHubPlugin.java
+++ b/src/main/java/fun/lewisdev/deluxehub/DeluxeHubPlugin.java
@@ -17,12 +17,14 @@ import fun.lewisdev.deluxehub.inventory.InventoryManager;
 import fun.lewisdev.deluxehub.module.ModuleManager;
 import fun.lewisdev.deluxehub.module.ModuleType;
 import fun.lewisdev.deluxehub.module.modules.hologram.HologramManager;
+import fun.lewisdev.deluxehub.module.modules.world.WorldLoadListener;
 import fun.lewisdev.deluxehub.utility.TextUtil;
 import fun.lewisdev.deluxehub.utility.UpdateChecker;
 import org.bstats.bukkit.MetricsLite;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -96,6 +98,12 @@ public class DeluxeHubPlugin extends JavaPlugin {
 
         // Action system
         actionManager = new ActionManager(this);
+
+        //Automatic world loading
+        if(getConfigManager().getFile(ConfigType.SETTINGS).getConfig().getBoolean("automatic-world-loading")) {
+            getLogger().info("Enabled automatic world loading!");
+            Bukkit.getPluginManager().registerEvents(new WorldLoadListener(this), this);
+        }
 
         // Load update checker (if enabled)
         if (getConfigManager().getFile(ConfigType.SETTINGS).getConfig().getBoolean("update-check"))

--- a/src/main/java/fun/lewisdev/deluxehub/module/ModuleManager.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/ModuleManager.java
@@ -45,12 +45,41 @@ public class ModuleManager {
     }
 
     /**
-     * @param string name of a world
+     * @param world name of a world
      */
-    public boolean disableWorld(String string) {
-        if(Bukkit.getWorld(string) != null)
-            return disabledWorlds.add(string);
-        throw new IllegalArgumentException("cant find world: " + string)
+    public boolean disableWorld(String world) {
+        if(Bukkit.getWorld(world) != null)
+            return disabledWorlds.add(world);
+        throw new IllegalArgumentException("cant find world: " + world);
+    }
+
+    public void registerNewWorld(String world) {
+        if(Bukkit.getWorld(world) != null)
+        {
+            FileConfiguration config = plugin.getConfigManager().getFile(ConfigType.SETTINGS).getConfig();
+            if (config.getBoolean("disabled-worlds.invert")) { //whitelist
+                if (config.getStringList("disabled-worlds.worlds").contains(world)) {
+                    //allow
+                    disabledWorlds.remove(world); // just in case
+                    plugin.getLogger().info("Loaded new world: " + world + "! The world was added to the whitelist!");
+                }else {
+                    disableWorld(world);
+                    plugin.getLogger().info("Loaded new world: " + world + "! The world is not on the whitelist and was marked as disabled!");
+                }
+            }else {
+                if (config.getStringList("disabled-worlds.worlds").contains(world)) {
+                    //deny
+                    disableWorld(world);
+                    plugin.getLogger().info("Loaded new world: " + world + "! The world is on the blacklist and was marked as disabled!");
+                }else {
+                    disabledWorlds.remove(world); //just in case
+                    plugin.getLogger().info("Loaded new world: " + world + "! The world is not on the blacklist and was marked as enabled!");
+                }
+            }
+            return;
+
+        }
+        throw new IllegalArgumentException("cant find world: " + world);
     }
 
     public void loadModules(DeluxeHubPlugin plugin) {

--- a/src/main/java/fun/lewisdev/deluxehub/module/ModuleManager.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/ModuleManager.java
@@ -32,18 +32,34 @@ public class ModuleManager {
     private List<String> disabledWorlds;
     private Map<ModuleType, Module> modules = new HashMap<>();
 
+
+    public void loadWorlds() {
+        FileConfiguration config = plugin.getConfigManager().getFile(ConfigType.SETTINGS).getConfig();
+        if (config.getBoolean("disabled-worlds.invert")) {
+            disabledWorlds = Bukkit.getWorlds().stream().map(World::getName).collect(Collectors.toList());
+            for (String world : config.getStringList("disabled-worlds.worlds")) disabledWorlds.remove(world);
+        }else {
+            disabledWorlds = config.getStringList("disabled-worlds.worlds");
+        }
+
+    }
+
+    /**
+     * @param string name of a world
+     */
+    public boolean disableWorld(String string) {
+        if(Bukkit.getWorld(string) != null)
+            return disabledWorlds.add(string);
+        throw new IllegalArgumentException("cant find world: " + string)
+    }
+
     public void loadModules(DeluxeHubPlugin plugin) {
         this.plugin = plugin;
 
         if (!modules.isEmpty()) unloadModules();
 
-        FileConfiguration config = plugin.getConfigManager().getFile(ConfigType.SETTINGS).getConfig();
-        disabledWorlds = config.getStringList("disabled-worlds.worlds");
-
-        if (config.getBoolean("disabled-worlds.invert")) {
-            disabledWorlds = Bukkit.getWorlds().stream().map(World::getName).collect(Collectors.toList());
-                for (String world : config.getStringList("disabled-worlds.worlds")) disabledWorlds.remove(world);
-        }
+        //#loadWorlds
+        loadWorlds();
 
         registerModule(new AntiWorldDownloader(plugin), "anti_wdl.enabled");
         registerModule(new DoubleJump(plugin), "double_jump.enabled");

--- a/src/main/java/fun/lewisdev/deluxehub/module/modules/world/WorldLoadListener.java
+++ b/src/main/java/fun/lewisdev/deluxehub/module/modules/world/WorldLoadListener.java
@@ -1,0 +1,25 @@
+package fun.lewisdev.deluxehub.module.modules.world;
+
+import fun.lewisdev.deluxehub.DeluxeHubPlugin;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.WorldLoadEvent;
+
+/**
+ * @author Ture Bentzin
+ * @since 11-09-2023
+ */
+public class WorldLoadListener implements Listener {
+
+    private final DeluxeHubPlugin plugin;
+
+    public WorldLoadListener(DeluxeHubPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onWorldLoad(WorldLoadEvent worldLoadEvent) {
+        //only listens if automatic-world-load is true so no checks here
+        plugin.getModuleManager().registerNewWorld(worldLoadEvent.getWorld().getName()); //name used because plugin uses names elsewhere
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -57,6 +57,9 @@ disabled-worlds:
   worlds:
     - world_nether
 
+# Automatically load new worlds
+automatic-world-loading: false
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 # | ANTI-WORLD DOWNLOADER                    | 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#


### PR DESCRIPTION
This pull request ist about this conversation: https://discord.com/channels/411229508838883329/548534592533954589/1150782258014339154

It added two things to DeluxeHub

###  Automatic world loading
This feature populates the "disabledWorlds" if a new world is loaded. It respects the configuration about whitelist / blacklist

### Methods:

```java
public void loadWorlds() {
        FileConfiguration config = plugin.getConfigManager().getFile(ConfigType.SETTINGS).getConfig();
        if (config.getBoolean("disabled-worlds.invert")) {
            disabledWorlds = Bukkit.getWorlds().stream().map(World::getName).collect(Collectors.toList());
            for (String world : config.getStringList("disabled-worlds.worlds")) disabledWorlds.remove(world);
        }else {
            disabledWorlds = config.getStringList("disabled-worlds.worlds");
        }

    }

    /**
     * @param world name of a world
     */
    public boolean disableWorld(String world) {
        if(Bukkit.getWorld(world) != null)
            return disabledWorlds.add(world);
        throw new IllegalArgumentException("cant find world: " + world);
    }

    public void registerNewWorld(String world) {
        if(Bukkit.getWorld(world) != null)
        {
            FileConfiguration config = plugin.getConfigManager().getFile(ConfigType.SETTINGS).getConfig();
            if (config.getBoolean("disabled-worlds.invert")) { //whitelist
                if (config.getStringList("disabled-worlds.worlds").contains(world)) {
                    //allow
                    disabledWorlds.remove(world); // just in case
                    plugin.getLogger().info("Loaded new world: " + world + "! The world was added to the whitelist!");
                }else {
                    disableWorld(world);
                    plugin.getLogger().info("Loaded new world: " + world + "! The world is not on the whitelist and was marked as disabled!");
                }
            }else {
                if (config.getStringList("disabled-worlds.worlds").contains(world)) {
                    //deny
                    disableWorld(world);
                    plugin.getLogger().info("Loaded new world: " + world + "! The world is on the blacklist and was marked as disabled!");
                }else {
                    disabledWorlds.remove(world); //just in case
                    plugin.getLogger().info("Loaded new world: " + world + "! The world is not on the blacklist and was marked as enabled!");
                }
            }
            return;

        }
        throw new IllegalArgumentException("cant find world: " + world);
    }
    ```
    
### Needs attention
I used a new Listener to listen for WorldLoadEvents (fun/lewisdev/deluxehub/module/modules/world/WorldLoadListener.java). That listener is only active if the config flag for automatic world loading is set to true (by default it is false). I put in in the "GENERAL SETTINGS" section, because I think it fits there best.
```yaml
# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
# | GENERAL SETTINGS                         |
# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#

# Check for latest SpigotMC updates (recommended).
check-updates: true

# Disable specific worlds
disabled-worlds:
  # Should we invert the list making it a whitelist rather than a blacklist?
  invert: false
  # List your disabled worlds HERE or "worlds: []" to disable
  worlds:
    - world_nether

# Automatically load new worlds
automatic-world-loading: false
```

I don't know what your policy for the developers tag in the pom.xml is.

This PR also bumps the version to *.5.5 because its only a minor change.

**If you think I should have done this in a different way, because it violates your code style. Please let me know**

_Further testing is still needed, that is why it is a draft_

