### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/src/main/java/fun/lewisdev/deluxehub/utility/reflection/ActionBar.java
+++ b/src/main/java/fun/lewisdev/deluxehub/utility/reflection/ActionBar.java
@@ -49,7 +49,7 @@ import java.util.concurrent.Callable;
  * Messages are not colorized by default.
  * <p>
  * Action bars are text messages that appear above
- * the player's <a href="https://minecraft.gamepedia.com/Heads-up_display">hotbar</a>
+ * the player's <a href="https://minecraft.wiki/w/Heads-up_display">hotbar</a>
  * Note that this is different than the text appeared when switching between items.
  * Those messages show the item's name and are different from action bars.
  * The only natural way of displaying action bars is when mounting.

--- a/src/main/java/fun/lewisdev/deluxehub/utility/reflection/Titles.java
+++ b/src/main/java/fun/lewisdev/deluxehub/utility/reflection/Titles.java
@@ -44,7 +44,7 @@ import java.util.Objects;
  * Messages are not colorized by default.
  * <p>
  * Titles are text messages that appear in the
- * middle of the players screen: https://minecraft.gamepedia.com/Commands/title
+ * middle of the players screen: https://minecraft.wiki/w/Commands/title
  * PacketPlayOutTitle: https://wiki.vg/Protocol#Title
  *
  * @author Crypto Morin

--- a/src/main/java/fun/lewisdev/deluxehub/utility/universal/XMaterial.java
+++ b/src/main/java/fun/lewisdev/deluxehub/utility/universal/XMaterial.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
  * This class is mainly designed to support {@link ItemStack}. If you want to use it on blocks, you'll have to use
  * <a href="https://github.com/CryptoMorin/XSeries/blob/master/src/main/java/com/cryptomorin/xseries/XBlock.java">XBlock</a>
  * <p>
- * Pre-flattening: https://minecraft.gamepedia.com/Java_Edition_data_values/Pre-flattening
+ * Pre-flattening: https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening
  * Materials: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html
  * Materials (1.12): https://helpch.at/docs/1.12.2/index.html?org/bukkit/Material.html
  * Material IDs: https://minecraft-ids.grahamedgecombe.com/
@@ -57,7 +57,7 @@ import java.util.stream.Collectors;
  * <p>
  * This class will throw an "unsupported material" error if someone tries to use an item with an invalid data value which can only happen in 1.12 servers and below or when the
  * utility is missing a new material in that specific version.
- * To get an invalid item, (aka <a href="https://minecraft.fandom.com/wiki/Missing_Texture_Block">Missing Texture Block</a>) you can use the command
+ * To get an invalid item, (aka <a href="https://minecraft.wiki/w/Missing_textures_and_models">Missing Texture</a>) you can use the command
  * <b>/give @p minecraft:dirt 1 10</b> where 1 is the item amount, and 10 is the data value. The material {@link #DIRT} with a data value of {@code 10} doesn't exist.
  *
  * @author Crypto Morin
@@ -87,7 +87,7 @@ public enum XMaterial {
     ACACIA_WOOD(0, "LOG_2"),
     ACTIVATOR_RAIL,
     /**
-     * <a href="https://minecraft.gamepedia.com/Air">Air</a>
+     * <a href="https://minecraft.wiki/w/Air">Air</a>
      * {@link Material#isAir()}
      *
      * @see #VOID_AIR
@@ -966,7 +966,7 @@ public enum XMaterial {
     NETHER_SPROUTS,
     NETHER_STAR,
     /**
-     * Just like mentioned in <a href="https://minecraft.gamepedia.com/Nether_Wart">Nether Wart</a>
+     * Just like mentioned in <a href="https://minecraft.wiki/w/Nether_Wart">Nether Wart</a>
      * Nether wart is also known as nether stalk in the code.
      * NETHER_STALK is the planted state of nether warts.
      */
@@ -1665,7 +1665,7 @@ public enum XMaterial {
     }
 
     /**
-     * The data value of this material <a href="https://minecraft.gamepedia.com/Java_Edition_data_values/Pre-flattening">Pre-flattening</a>
+     * The data value of this material <a href="https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening">Pre-flattening</a>
      * It's never a negative number.
      *
      * @see #getData()
@@ -2159,7 +2159,7 @@ public enum XMaterial {
     }
 
     /**
-     * The data value of this material <a href="https://minecraft.gamepedia.com/Java_Edition_data_values/Pre-flattening">pre-flattening</a>.
+     * The data value of this material <a href="https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening">pre-flattening</a>.
      * <p>
      * Can be accessed with {@link ItemStack#getData()} then {@code MaterialData#getData()}
      * or {@link ItemStack#getDurability()} if not damageable.

--- a/src/main/java/fun/lewisdev/deluxehub/utility/universal/XPotion.java
+++ b/src/main/java/fun/lewisdev/deluxehub/utility/universal/XPotion.java
@@ -47,8 +47,8 @@ import java.util.regex.Pattern;
  * Amplifier: The amplifier of the effect, with level I having value 0. Optional, and defaults to level I.
  * <p>
  * EssentialsX Potions: https://github.com/EssentialsX/Essentials/blob/2.x/Essentials/src/com/earth2me/essentials/Potions.java
- * Status Effect: https://minecraft.gamepedia.com/Status_effect
- * Potions: https://minecraft.gamepedia.com/Potion
+ * Status Effect: https://minecraft.wiki/w/Status_effect
+ * Potions: https://minecraft.wiki/w/Potion
  *
  * @author Crypto Morin
  * @version 1.1.0

--- a/src/main/java/fun/lewisdev/deluxehub/utility/universal/XSound.java
+++ b/src/main/java/fun/lewisdev/deluxehub/utility/universal/XSound.java
@@ -56,7 +56,7 @@ import java.util.regex.Pattern;
  * 1.8: http://docs.codelanx.com/Bukkit/1.8/org/bukkit/Sound.html
  * Latest: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Sound.html
  * Basics: https://bukkit.org/threads/151517/
- * playSound command: https://minecraft.gamepedia.com/Commands/playsound
+ * playSound command: https://minecraft.wiki/w/Commands/playsound
  *
  * @author Crypto Morin
  * @version 2.2.0


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.